### PR TITLE
Fixes how structured.proc_df() one hot encoding works on a test set.

### DIFF
--- a/fastai/structured.py
+++ b/fastai/structured.py
@@ -319,7 +319,7 @@ def numericalize(df, col, name, max_n_cat):
     1     2    b    2
     2     3    a    1
     """
-    if not is_numeric_dtype(col) and ( max_n_cat is None or col.nunique()>max_n_cat):
+    if not is_numeric_dtype(col) and ( max_n_cat is None or len(col.cat.categories)>max_n_cat):
         df[name] = col.cat.codes+1
 
 def scale_vars(df, mapper):


### PR DESCRIPTION
The problem:
When we pass max_n_cat to proc_df() it looks at the number of distinct values to decide whether to expand it into 1-hot encoded columns or not.
The issue arrises when the test set has smaller number of distinct values and falls below the treshold while the train set doesn't. We end up with different sets of columns in the two sets.

Proposed solution:
Rather than look at the count of distinct values look at the number of categories associated with the column. This will be the same between the sets if train_cats(), apply_cats() functions were use

Example:
    df1 = pd.DataFrame({'col1':['a','b','c']})
    df2 = pd.DataFrame({'col1':['a','b','b']})
    train_cats(df1)
    apply_cats(df2, df1)
    df1_proc,*_ = proc_df(df1, max_n_cat=2)
    df2_proc,*_ = proc_df(df2, max_n_cat=2)
    set(df1_proc.columns) == set(df2_proc.columns)

Used to return False and now returns True

Test Plan:
    - Run the Example above
    - Loaded a test set with a mix of numerical, low and high cardinality categories. Verify that things work as before.